### PR TITLE
Add DDR5 Memory Device Type

### DIFF
--- a/smbios_validation_tool/constants.py
+++ b/smbios_validation_tool/constants.py
@@ -51,7 +51,7 @@ class FieldValueEnums(enum.Enum):
   PHYSICAL_MEMORY_ARRAY_LOCATION = ['System Board Or Motherboard']
   PHYSICAL_MEMORY_ARRAY_USE = ['System Memory']
   MEMORY_DEVICE_FORM_FACTOR = ['Unknown', 'DIMM']
-  MEMORY_DEVICE_TYPES = ['Unknown', 'DDR4', 'LPDDR4']
+  MEMORY_DEVICE_TYPES = ['Unknown', 'DDR4', 'LPDDR4', 'DDR5']
   IPMI_DEVICE_INTERFACE_TYPES = [
       'BT (Block Transfer)', 'KCS (Keyboard Control Style)'
   ]


### PR DESCRIPTION
In SMBIOS specification 3.4.0a, there's a new definition for DDR5 memory type (with value 22h) in Type 17 Table.

This patch add 'DDR5' in MEMORY_DEVICE_TYPES for it.