### PR TITLE
Validate Type 17 Serial Numbers are 9 byte on DDR5 platforms

### DIFF
--- a/rules/textproto/less.textproto
+++ b/rules/textproto/less.textproto
@@ -183,6 +183,20 @@ type_rule {
       field: "Part Number"
     }
   }
+  conditional_rule {
+    condition {
+      field: "Type"
+      validations {
+        regexp_validate: "DDR5"
+      }
+    }
+    rule {
+      field: "Serial Number"
+      validations {
+        regexp_validate: "^[a-fA-F0-9]{18}$"
+      }
+    }
+  }
 }
 
 # System Root Information


### PR DESCRIPTION
New requirement that DDR5 platforms report 9 byte serial number based on JEDEC standard.

This updated rule just conditionally checks for 18 character serial numbers if it is DDR5.